### PR TITLE
Fix file upload OpenAPI annotation

### DIFF
--- a/src/main/java/com/coreoz/jersey/JerseyConfigProvider.java
+++ b/src/main/java/com/coreoz/jersey/JerseyConfigProvider.java
@@ -1,14 +1,5 @@
 package com.coreoz.jersey;
 
-import jakarta.inject.Inject;
-import jakarta.inject.Provider;
-import jakarta.inject.Singleton;
-
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.glassfish.jersey.media.multipart.MultiPartFeature;
-import org.glassfish.jersey.process.internal.RequestScoped;
-import org.glassfish.jersey.server.ResourceConfig;
-
 import com.coreoz.plume.admin.jersey.feature.AdminSecurityFeature;
 import com.coreoz.plume.admin.jersey.feature.RestrictToAdmin;
 import com.coreoz.plume.admin.websession.WebSessionAdmin;
@@ -19,7 +10,15 @@ import com.coreoz.plume.jersey.errors.WsResultExceptionMapper;
 import com.coreoz.plume.jersey.java8.TimeParamProvider;
 import com.coreoz.plume.jersey.security.permission.PublicApi;
 import com.coreoz.plume.jersey.security.permission.RequireExplicitAccessControlFeature;
+import com.coreoz.plume.jersey.security.size.ContentSizeLimitFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.glassfish.jersey.server.ResourceConfig;
 
 /**
  * Jersey configuration
@@ -51,6 +50,8 @@ public class JerseyConfigProvider implements Provider<ResourceConfig> {
 		// filters configuration
 		// handle errors and exceptions
 		config.register(WsResultExceptionMapper.class);
+        // Limit request body size to 500kb
+        config.register(ContentSizeLimitFeature.class);
 		// require explicit access control on API
 		config.register(RequireExplicitAccessControlFeature.accessControlAnnotations(PublicApi.class, RestrictToAdmin.class));
 		// admin web-services protection with the permission system

--- a/src/main/java/com/coreoz/webservices/api/file/FileUploadRequest.java
+++ b/src/main/java/com/coreoz/webservices/api/file/FileUploadRequest.java
@@ -1,0 +1,20 @@
+package com.coreoz.webservices.api.file;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+
+import java.io.InputStream;
+
+@Data
+public class FileUploadRequest {
+    @Hidden
+    @FormDataParam("file")
+    private FormDataBodyPart fileMetadata;
+
+    @Schema(name = "file", type = "string", format = "binary")
+    @FormDataParam("file")
+    private InputStream fileData;
+}

--- a/src/main/java/com/coreoz/webservices/api/file/FileUploadWs.java
+++ b/src/main/java/com/coreoz/webservices/api/file/FileUploadWs.java
@@ -7,21 +7,20 @@ import com.coreoz.plume.file.validator.FileUploadValidator;
 import com.coreoz.plume.jersey.security.permission.PublicApi;
 import com.coreoz.services.file.ShowcaseFileType;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.glassfish.jersey.media.multipart.FormDataBodyPart;
-import org.glassfish.jersey.media.multipart.FormDataParam;
-
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.container.ContainerRequestContext;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.io.InputStream;
+
 import java.util.Set;
 
 @Path("/files")
@@ -46,14 +45,11 @@ public class FileUploadWs {
     @POST
     @Path("/pictures")
     @Operation(description = "Upload a file")
-    public Response uploadPicture(
-        @Context ContainerRequestContext context,
-        @FormDataParam("file") FormDataBodyPart fileMetadata,
-        @FormDataParam("file") InputStream fileData
-    ) {
+    @RequestBody(content = @Content(schema = @Schema(implementation = FileUploadRequest.class)))
+    public Response uploadPicture(@BeanParam FileUploadRequest request) {
         FileUploadData fileUploadMetadata = FileUploadValidator.from(
-                fileMetadata,
-                fileData,
+                request.getFileMetadata(),
+                request.getFileData(),
                 this.fileMimeTypeDetector
             )
             .fileMaxSize(2_000_000)
@@ -77,14 +73,11 @@ public class FileUploadWs {
     @POST
     @Path("/reports")
     @Operation(description = "Upload a file")
-    public Response uploadExcelFile(
-        @Context ContainerRequestContext context,
-        @FormDataParam("file") FormDataBodyPart fileMetadata,
-        @FormDataParam("file") InputStream fileData
-    ) {
+    @RequestBody(content = @Content(schema = @Schema(implementation = FileUploadRequest.class)))
+    public Response uploadExcelFile(@BeanParam FileUploadRequest request) {
         FileUploadData fileUploadMetadata = FileUploadValidator.from(
-                fileMetadata,
-                fileData,
+                request.getFileMetadata(),
+                request.getFileData(),
                 this.fileMimeTypeDetector
             )
             .fileMaxSize(2_000_000)


### PR DESCRIPTION
Cela permet d'avoir une documentation OpenAPI propre et utilisable avec swagger-ui pour ajouter directement des fichiers.

Par contre, il faudra aussi mettre la documentation de Plume File avec ça.